### PR TITLE
changed print to python3 friendly

### DIFF
--- a/hobbs.py
+++ b/hobbs.py
@@ -7,7 +7,7 @@ import sys
 import nltk
 from nltk.corpus import names
 from nltk import Tree
-import Queue
+import queue as Queue
 
 
 # Labels for nominal heads
@@ -449,34 +449,34 @@ def demo():
     tree6 = Tree.fromstring('(S (NP (NNP John) ) (VP (VBD said) (SBAR (-NONE- 0) \
         (S (NP (NNP Mary) ) (VP (VBD likes) (NP (PRP herself) ) ) ) ) ) )')
 
-    print "Sentence 1:"
-    print tree1
+    print("Sentence 1:")
+    print(tree1)
     tree, pos = hobbs([tree1], (1,1,1,0,0))
-    print "Proposed antecedent for 'he':", tree[pos], '\n'
+    print ("Proposed antecedent for 'he':", tree[pos], '\n')
 
-    print "Sentence 2:"
-    print tree2
+    print ("Sentence 2:")
+    print (tree2)
     tree, pos = hobbs([tree2], (1,1,1,1,1,0))
-    print "Proposed antecedent for 'him':", tree[pos], '\n'
+    print ("Proposed antecedent for 'him':", tree[pos], '\n')
 
-    print "Sentence 3:"
-    print tree3
-    print "Sentence 4:"
-    print tree4
+    print ("Sentence 3:")
+    print (tree3)
+    print ("Sentence 4:")
+    print (tree4)
     tree, pos = hobbs([tree3,tree4], (1,1,0))
-    print "Proposed antecedent for 'it':", tree[pos]
+    print ("Proposed antecedent for 'it':", tree[pos])
     tree, pos = hobbs([tree3,tree4], (0,0))
-    print "Proposed antecedent for 'he':", tree[pos], '\n'
+    print ("Proposed antecedent for 'he':", tree[pos], '\n')
 
-    print "Sentence 5:"
-    print tree5
+    print ("Sentence 5:")
+    print (tree5)
     tree, pos = hobbs([tree5], (1,2,1,1,0,0))
-    print "Proposed antecedent for 'he':", tree[pos], '\n'
+    print ("Proposed antecedent for 'he':", tree[pos], '\n')
 
-    print "Sentence 6:"
-    print tree6
+    print ("Sentence 6:")
+    print (tree6)
     tree, pos = resolve_reflexive([tree6], (1,1,1,1,1,0))
-    print "Proposed antecedent for 'herself':", tree[pos], '\n'
+    print ("Proposed antecedent for 'herself':", tree[pos], '\n')
 
 
 def main(argv):
@@ -484,7 +484,7 @@ def main(argv):
         demo()
     else:
         if len(sys.argv) > 3 or len(sys.argv) < 2:
-            print "Enter the file and the pronoun to resolve."
+            print ("Enter the file and the pronoun to resolve.")
         elif len(sys.argv) == 3:
             p = ["He", "he", "Him", "him", "She", "she", "Her",
                 "her", "It", "it", "They", "they"]
@@ -500,13 +500,13 @@ def main(argv):
             if pro in p:
                 tree, pos = hobbs(trees, pos)
                 for t in trees:
-                    print t, '\n'
-                print "Proposed antecedent for '"+pro+"':", tree[pos]
+                    print (t, '\n')
+                print ("Proposed antecedent for '"+pro+"':", tree[pos])
             elif pro in r:
                 tree, pos = resolve_reflexive(trees, pos)
                 for t in trees:
-                    print t, '\n'
-                print "Proposed antecedent for '"+pro+"':", tree[pos]
+                    print (t, '\n')
+                print ("Proposed antecedent for '"+pro+"':", tree[pos])
 
 if __name__ == "__main__":
     main(sys.argv)


### PR DESCRIPTION
With the switch to python, the following changes affect the script 

- print 'Something' became print('Something') 
- The Library Queue is imported as `import queue`  instead of  `import Queue`. The latter gives `ModuleNotFoundError: No module named 'Queue' `